### PR TITLE
[RC-297] - Filter Test Session Results

### DIFF
--- a/src/components/common/AdministratorGrid.js
+++ b/src/components/common/AdministratorGrid.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import FilterListIcon from '@material-ui/icons/FilterList';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import DownloadIcon from '@material-ui/icons/GetApp';
 import UploadIcon from '@material-ui/icons/Publish';
+import clsx from 'clsx';
 import { FileUploader, Button, Grid } from '.';
 
 function AdministratorGrid({
@@ -13,10 +15,13 @@ function AdministratorGrid({
     onCreate,
     onImport,
     onExport,
+    onFilter,
     entity,
     options,
     fetch,
     importFileTypes,
+    tableRef: tableRefProp,
+    filterApplied,
 }) {
     const fileMappings = {
         xlsx: [
@@ -27,14 +32,15 @@ function AdministratorGrid({
             'text/plain',
         ],
     };
-    const tableRef = React.createRef(null);
+    const tableRef = tableRefProp || React.createRef(null);
     return (
         <div
             className={`administrator-grids ${className}`}
             style={style}
         >
-            <div className='d-flex direction-row mb-4'>
-                {_.isFunction(onCreate)
+            <div className='d-flex direction-row mb-4 justify-content-between'>
+                <div className='d-flex direction-row'>
+                    {_.isFunction(onCreate)
                     && (
                         <Button
                             className='mr-3'
@@ -45,7 +51,7 @@ function AdministratorGrid({
                             Create
                         </Button>
                     )}
-                {_.isFunction(onImport)
+                    {_.isFunction(onImport)
                     && (
                         <FileUploader
                             acceptedFiles={_.reduce(
@@ -69,7 +75,7 @@ function AdministratorGrid({
                             }}
                         />
                     )}
-                {_.isFunction(onExport)
+                    {_.isFunction(onExport)
                     && (
                         <Button
                             className='mr-3'
@@ -81,6 +87,18 @@ function AdministratorGrid({
                             Export
                         </Button>
                     )}
+                </div>
+                {_.isFunction(onFilter) && (
+                    <Button
+                        className={clsx({ 'administrator-grids-applied-filter': filterApplied })}
+                        color='primary'
+                        onClick={onFilter}
+                        startIcon={<FilterListIcon />}
+                        variant='outlined'
+                    >
+                        {`${filterApplied ? 'Change' : 'Apply'} Filter`}
+                    </Button>
+                )}
             </div>
             <Grid
                 entity={entity}
@@ -101,11 +119,14 @@ AdministratorGrid.propTypes = {
     onCreate: PropTypes.func,
     onImport: PropTypes.func,
     onExport: PropTypes.func,
+    onFilter: PropTypes.func,
     options: PropTypes.object,
     importFileTypes: PropTypes.array,
     fetch: PropTypes.func,
     style: PropTypes.object,
     className: PropTypes.string,
+    filterApplied: PropTypes.bool,
+    tableRef: PropTypes.object,
 };
 
 AdministratorGrid.defaultProps = {
@@ -114,11 +135,14 @@ AdministratorGrid.defaultProps = {
     onCreate: undefined,
     onImport: undefined,
     onExport: undefined,
+    onFilter: undefined,
+    filterApplied: false,
     fetch: undefined,
     importFileTypes: ['xlsx'],
     options: {},
     style: undefined,
     className: '',
+    tableRef: undefined,
 };
 
 export default AdministratorGrid;

--- a/src/components/common/style.scss
+++ b/src/components/common/style.scss
@@ -395,3 +395,13 @@
 .infinite-list-card-selected {
     border: 0.1px solid $primary
 }
+
+.administrator-grids-applied-filter {
+    border-color: #1b8a16 !important;
+    color: #1b8a16 !important;
+}
+
+/* Bootstrap override */
+.hover {
+    z-index: 1050;
+}

--- a/src/components/testSessions/Grid.js
+++ b/src/components/testSessions/Grid.js
@@ -7,6 +7,10 @@ import { AdministratorGrid } from '../common';
 function TestSessionsGrid({
     onRowClick,
     onExport,
+    onFilter,
+    filterApplied,
+    tableRef,
+    query,
 }) {
     const format = datum => {
         datum.testName = _.get(datum, 'test.name');
@@ -19,9 +23,12 @@ function TestSessionsGrid({
     return (
         <AdministratorGrid
             entity='testSessions'
+            filterApplied={filterApplied}
             onExport={onExport}
+            onFilter={onFilter}
             onRowClick={onRowClick}
-            options={{ format }}
+            options={{ format, query }}
+            tableRef={tableRef}
             title='Test Sessions'
         />
     );
@@ -30,11 +37,19 @@ function TestSessionsGrid({
 TestSessionsGrid.propTypes = {
     onRowClick: PropTypes.func,
     onExport: PropTypes.func,
+    onFilter: PropTypes.func,
+    filterApplied: PropTypes.bool,
+    tableRef: PropTypes.object,
+    query: PropTypes.object,
 };
 
 TestSessionsGrid.defaultProps = {
     onRowClick: undefined,
     onExport: undefined,
+    onFilter: undefined,
+    filterApplied: undefined,
+    tableRef: undefined,
+    query: {},
 };
 
 export default TestSessionsGrid;

--- a/src/components/testSessions/TestSessions.js
+++ b/src/components/testSessions/TestSessions.js
@@ -36,7 +36,11 @@ export default function TestSessions() {
         <Layout className='my-4'>
             <TestSessionsGrid
                 filterApplied={!_.isEmpty(testSessions.filters)}
-                onExport={rolesCheckerService.has('Administrator') ? () => actions.onExport('application/zip', 'zip') : undefined}
+                onExport={
+                    rolesCheckerService.has('Administrator')
+                        ? () => actions.onExport('application/zip', 'zip', getQuery(testSessions.filters))
+                        : undefined
+                }
                 onFilter={() => setOpenFilterModal(true)}
                 onRowClick={actions.onRowClick}
                 query={getQuery(testSessions.filters)}

--- a/src/components/testSessions/TestSessions.js
+++ b/src/components/testSessions/TestSessions.js
@@ -1,18 +1,123 @@
+import _ from 'lodash';
 import React from 'react';
-import { Layout } from '../common';
+import moment from 'moment';
+import { Layout, ModalInfo } from '../common';
+import Form from '../form';
 import TestSessionsGrid from './Grid';
-import { useGridActions, useRolesCheckerService } from '../../hooks';
+import {
+    useGridActions,
+    useRolesCheckerService,
+    useForm,
+    useActions,
+    useStore,
+} from '../../hooks';
 
 export default function TestSessions() {
     const actions = useGridActions('testSessions');
     const rolesCheckerService = useRolesCheckerService();
+    const [openFilterModal, setOpenFilterModal] = React.useState(false);
+    const [filterApplied, setFilterApplied] = React.useState(false);
+    const testSessionsActions = useActions('testSessions');
+    const testSessions = useStore('testSessions');
+    const controls = useForm();
+    const tableRef = React.useRef(null);
+
+    const getQuery = filters => _.reduce(filters, (acc, value, key) => {
+        if (!_.isEmpty(value)) {
+            if (_.isObject(value)) {
+                value = _.get(value, 'id');
+            }
+            acc[_.snakeCase(key)] = value;
+        }
+        return acc;
+    }, {});
 
     return (
         <Layout className='my-4'>
             <TestSessionsGrid
+                filterApplied={!_.isEmpty(testSessions.filters)}
                 onExport={rolesCheckerService.has('Administrator') ? () => actions.onExport('application/zip', 'zip') : undefined}
+                onFilter={() => setOpenFilterModal(true)}
                 onRowClick={actions.onRowClick}
+                query={getQuery(testSessions.filters)}
+                tableRef={tableRef}
             />
+            <ModalInfo
+                onHide={() => {
+                    setOpenFilterModal(!openFilterModal);
+                    setFilterApplied(!filterApplied);
+                }}
+                show={openFilterModal}
+                title='Filter Test Session'
+            >
+                <Form
+                    buttons={[
+                        {
+                            title: 'Apply Filters',
+                            handler: data => {
+                                if (data.startDatetime instanceof moment) {
+                                    data.startDatetime = data.startDatetime.toISOString();
+                                }
+                                if (data.endDatetime instanceof moment) {
+                                    data.endDatetime = data.endDatetime.toISOString();
+                                }
+                                testSessionsActions.setFilters(data);
+                                setOpenFilterModal(false);
+                                tableRef.current && tableRef.current.onQueryChange();
+                            },
+                        },
+                        {
+                            title: 'Remove Filters',
+                            handler: () => {
+                                testSessionsActions.setFilters({});
+                                setOpenFilterModal(false);
+                                tableRef.current.onQueryChange();
+                            },
+                        },
+                    ]}
+                    controls={controls}
+                    data={testSessions.filters}
+                    layout={[
+                        {
+                            field: 'startDatetime',
+                            title: 'Start Datetime',
+                            defaultValue: null,
+                            type: 'datetime',
+                        },
+                        {
+                            field: 'endDatetime',
+                            title: 'End Datetime',
+                            defaultValue: null,
+                            type: 'datetime',
+                        },
+                        {
+                            field: 'classId',
+                            title: 'Class',
+                            type: 'api-picklist',
+                            entity: 'studentClass',
+                        },
+                        {
+                            field: 'studentId',
+                            title: 'Student',
+                            type: 'api-picklist',
+                            entity: 'student',
+                        },
+                        {
+                            field: 'testId',
+                            title: 'Test',
+                            type: 'api-picklist',
+                            entity: 'test',
+                        },
+                        {
+                            field: 'instructorId',
+                            title: 'Instructor',
+                            query: { roles: 'Instructor' },
+                            type: 'api-picklist',
+                            entity: 'user',
+                        },
+                    ]}
+                />
+            </ModalInfo>
         </Layout>
     );
 }

--- a/src/hooks/useGridActions.js
+++ b/src/hooks/useGridActions.js
@@ -32,9 +32,9 @@ export default function useGridActions(entity, options = {}) {
         }
     };
 
-    const onExport = async (type, extension) => {
+    const onExport = async (type, extension, query) => {
         try {
-            const file = await service.export();
+            const file = await service.export(null, { query });
             type = !_.isNil(type) ? type : 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
             extension = !_.isNil(extension) ? extension : 'xlsx';
             if (_.isFunction(exportCallback)) {

--- a/src/redux/slices/index.js
+++ b/src/redux/slices/index.js
@@ -15,6 +15,7 @@ import instructorStudentClasses from './instructorStudentClasses';
 import testTakerStudentClasses from './testTakerStudentClasses';
 import testWizardSessionPreview from './testWizardSessionPreview';
 import testDeveloperTestsGridFilter from './testDeveloperTestsGridFilter';
+import testSessions from './testSessions';
 import { logout, resetTestWizardSession, endTestWizardSession } from '../globalActions';
 
 export const actions = {
@@ -40,6 +41,7 @@ export const actions = {
         endTestWizardSession,
     }),
     testDeveloperTestsGridFilter: testDeveloperTestsGridFilter.actions,
+    testSessions: testSessions.actions,
 };
 
 export const reducers = {
@@ -59,4 +61,5 @@ export const reducers = {
     testTakerStudentClasses: testTakerStudentClasses.reducer,
     testWizardSessionPreview: testWizardSessionPreview.reducer,
     testDeveloperTestsGridFilter: testDeveloperTestsGridFilter.reducer,
+    testSessions: testSessions.reducer,
 };

--- a/src/redux/slices/testSessions.js
+++ b/src/redux/slices/testSessions.js
@@ -1,0 +1,22 @@
+import { createSlice } from '@reduxjs/toolkit';
+import { logout } from '../globalActions';
+
+const initialState = { filters: {} };
+
+export default createSlice({
+    name: 'testSessions',
+    initialState,
+    reducers: {
+        setFilters: (state, action) => {
+            state.filters = action.payload;
+        },
+        reset: state => {
+            Object.assign(state, initialState);
+        },
+    },
+    extraReducers: {
+        [logout]: state => {
+            Object.assign(state, initialState);
+        },
+    },
+});

--- a/src/services/RestService.js
+++ b/src/services/RestService.js
@@ -73,10 +73,14 @@ export default class RestService {
     _export = (id, options = {}) => {
         let url = `${this.prefix}/export`;
         url = !_.isNil(id) ? `${url}?id=${id}` : url;
+        const query = _.get(options, 'query');
         const config = {
             responseType: 'arraybuffer',
             headers: { 'Content-Type': 'blob' },
         };
+        if (!_.isNil(query) && !_.isEmpty(query) && _.isObject(query)) {
+            config.params = query;
+        }
         return axios
             .get(url, config)
             .then(data => this._processResponse(data, options));

--- a/src/services/TestAssignationService.js
+++ b/src/services/TestAssignationService.js
@@ -33,6 +33,8 @@ class TestAssignation extends RestService {
     remove = this._remove;
 
     count = this._count;
+
+    export = this._export;
 }
 
 const testAssignationService = new TestAssignation();


### PR DESCRIPTION
Changes made this PR:
- Added Test Session Filters that can be applied to a grid.
- This Test Session filter is then persisted globally, meaning leaving the view will not remove the filters
- This filter is then sent along with the request to retrieve test sessions, test sessions count and test session export.